### PR TITLE
Override 'My account' page to disable editing of user details

### DIFF
--- a/app/views/my/account.html.erb
+++ b/app/views/my/account.html.erb
@@ -1,0 +1,72 @@
+<div class="contextual">
+<%= additional_emails_link(@user) %>
+<%# link_to(l(:button_change_password), {:action => 'password'}, :class => 'icon icon-passwd') if @user.change_password_allowed? %>
+<%= call_hook(:view_my_account_contextual, :user => @user)%>
+</div>
+
+<h2>
+  <%= avatar_edit_link(@user, :size => "50") %>
+  <%=l(:label_my_account)%>
+</h2>
+
+<div class="warning">
+<p>
+With Postgres community login your account details such as <b>First name, Last
+name, Primary Email and Password</b> are managed centrally.
+</p>
+<p>
+In order to change any of those, please update them at:
+<a href="https://www.postgresql.org/account/">https://www.postgresql.org/account/</a>,
+then log out of Redmine and log in once again for the changes to take effect.
+</p>
+</div>
+
+<%= error_messages_for 'user' %>
+
+<%= labelled_form_for :user, @user,
+                     :url => { :action => "account" },
+                     :html => { :id => 'my_account_form',
+                                :method => :post } do |f| %>
+<div class="splitcontentleft">
+<fieldset class="box tabular">
+  <legend><%=l(:label_information_plural)%></legend>
+  <p><%= f.text_field :firstname, :required => true, :disabled => true %></p>
+  <p><%= f.text_field :lastname, :required => true, :disabled => true  %></p>
+  <p><%= f.text_field :mail, :required => true, :disabled => true  %></p>
+  <% unless @user.force_default_language? %>
+  <p><%= f.select :language, lang_options_for_select %></p>
+  <% end %>
+  <% if Setting.openid? %>
+  <p><%= f.text_field :identity_url  %></p>
+  <% end %>
+
+  <% @user.custom_field_values.select(&:editable?).each do |value| %>
+    <p><%= custom_field_tag_with_label :user, value %></p>
+  <% end %>
+  <%= call_hook(:view_my_account, :user => @user, :form => f) %>
+</fieldset>
+
+<p class="mobile-hide"><%= submit_tag l(:button_save) %></p>
+</div>
+
+<div class="splitcontentright">
+<fieldset class="box">
+  <legend><%=l(:field_mail_notification)%></legend>
+  <%= render :partial => 'users/mail_notifications' %>
+</fieldset>
+
+<fieldset class="box tabular">
+  <legend><%=l(:label_preferences)%></legend>
+  <%= render :partial => 'users/preferences' %>
+  <%= call_hook(:view_my_account_preferences, :user => @user, :form => f) %>
+</fieldset>
+
+<p class="mobile-show"><%= submit_tag l(:button_save) %></p>
+</div>
+<% end %>
+
+<% content_for :sidebar do %>
+<%= render :partial => 'sidebar' %>
+<% end %>
+
+<% html_title(l(:label_my_account)) -%>


### PR DESCRIPTION
User name, email and password are managed by Postgres comminity login.  It is
confusing when people try to edit them in Redmine.

Disable input form fields and hide 'Change password' button, but add an
explanatory banner.

The fix is incomplete, because controller still allows changing these details.
But to use this loophole, a user will need to perform some actions manually
and they were warned not to do that.